### PR TITLE
Add European Portuguese (pt) locale

### DIFF
--- a/texts/index.ts
+++ b/texts/index.ts
@@ -16,6 +16,7 @@ import ja from './ja'
 import no from './no'
 import ua from './ua'
 import ar from './ar'
+import pt from './pt'
 
 export const defaultLang = process.env.NEXT_PUBLIC_DEFAULT_LANG as Lang
 
@@ -38,6 +39,7 @@ export const byLang = {
   tr,
   // ar,
   ru,
+  pt,
 } as const
 
 export const flagsMap: Record<Lang, string> = {
@@ -59,6 +61,7 @@ export const flagsMap: Record<Lang, string> = {
   ja: '🇯🇵',
   // ar: '🇦🇪',
   ru: '🏳',
+  pt: '🇵🇹',
 }
 
 export type Lang = keyof typeof byLang

--- a/texts/pt.ts
+++ b/texts/pt.ts
@@ -1,0 +1,149 @@
+// AI-assisted draft (European Portuguese), pending native review
+export default {
+  siteName: `Stand For Ukraine`,
+  siteDescription: `Apoia organizações militares e humanitárias ucranianas. Fundos verificados que ajudam as Forças Armadas e quem foi afetado pela guerra.`,
+  thumbnail: `/thumbnail.png`,
+
+  share: 'Partilhar',
+  donate: 'Doar',
+  inform: 'Informar',
+  donateButton: 'Doar',
+  spreadTheWorld: 'Spread the word',
+
+  heroTitle: 'Apoia organizações militares e humanitárias ucranianas',
+  heroSubtitle:
+    'Organizações de ajuda e fundos militares verificados — para apoiar as Forças Armadas da Ucrânia e quem foi afetado pela guerra.',
+  heroTagline: 'Pela Ucrânia, perante a invasão russa em larga escala.',
+
+  close: 'Fechar',
+  sharePopupTitle: 'Divulga a causa',
+  sharePopupText1: 'Partilha este projeto com amigos e colegas.',
+  sharePopupText2: 'Mostra às pessoas como podem apoiar a Ucrânia.',
+  sharingText: 'Apoia as Forças Armadas e organizações humanitárias da Ucrânia #StandForUkraine',
+  copyLink: 'Copiar ligação',
+  copyLinkDone: 'Copiado!',
+
+  // tags
+  All: 'Todas',
+  Military: 'Militar',
+  Medical: 'Médica',
+  Humanitarian: 'Humanitária',
+  Refugees: 'Ajuda a refugiados',
+  Press: 'Imprensa',
+  'Non-combat': 'Apoio não-combatente',
+  NGO: 'ONG',
+  'Human Rights': 'Direitos Humanos',
+
+  // footer
+  footerMissionLead:
+    'ajuda-te a apoiar a Ucrânia — de forma direta, segura e como te for mais conveniente. Encontra organizações e doa onde mais conta.',
+  footerGoals: 'Os nossos objetivos',
+  goal1:
+    'Fornecer às Forças Armadas ucranianas armas, munições e equipamento para resistir à invasão russa em larga escala.',
+  goal2: 'Apoiar a recuperação de veteranos e vítimas de guerra.',
+  goal3: 'Acolher e alimentar pessoas deslocadas.',
+  goal4: 'Ajudar crianças, idosos e outros grupos vulneráveis.',
+  goal5: 'Reforçar o jornalismo independente.',
+  footerCreds:
+    'Feito por voluntários — engenheiros, designers, jornalistas e ativistas da Ucrânia e de outros países.',
+  footerContact: 'Fala connosco',
+  joinUs: 'Junta-te a nós',
+  disclaimer:
+    'Não processamos doações — apenas te ligamos a angariações verificadas e transparentes.',
+  aboutProject: 'Sobre o projeto',
+  suggestOrgLink: 'Sugere uma organização',
+  sharedFeedbackLink: 'Deixa a tua opinião',
+  footerVerifyYouControl: 'Verificar via youcontrol.com',
+  footerLastReviewed: 'Última revisão: março de 2026',
+
+  // filter
+  filterTo: 'Causa',
+  filterPayVia: 'Via',
+  resetFilter: 'Limpar filtro',
+  moreFilters: 'Mais filtros',
+
+  // payment methods
+  IBAN: 'IBAN',
+  Crypto: 'Cripto',
+  'Credit Card': 'Cartão de crédito',
+  PayPal: 'PayPal',
+  Patreon: 'Patreon',
+
+  copyCode: 'Copiar código',
+  browseAll1: 'Ver todas',
+  browseAll2: 'as organizações',
+  browseAll3: 'as publicações',
+
+  // legal popup
+  legalCodeLabel: 'ЄДРПОУ',
+  legalDesc1:
+    'O EDRPOU (ЄДРПОУ) é o código de identificação de uma entidade legal, emitido pelo Serviço Fiscal do Estado da Ucrânia.',
+  legalDesc2: 'Copiar o código EDRPOU',
+  legalDesc3: 'Verificar a organização pelo código no registo',
+  legalFooterLink: 'Serviço Fiscal do Estado da Ucrânia',
+
+  // about page (English-only by design — kept for key parity, falls back to EN)
+  aboutHeader: `About the Project`,
+  aboutHeaderText1: `Who we are and what we stand for.`,
+
+  aboutManifestoHeader: 'Our Manifesto',
+  aboutManifestoText1:
+    'On Feb 24, 2022, Russia, with the active support of Belarus, launched a full-scale war on Ukraine.',
+  aboutManifestoText2:
+    'We are Ukrainians. We vigorously oppose this war and demand to end it immediately. It’s an attack on our liberty and genocide of our people. We are united and strong, but we can’t take on these atrocities on our own.',
+  aboutManifestoText3:
+    'Our project is a response to the invasion. We hope to reach people across the world, of all cultures and creeds, to come together and support Ukraine in its darkest hour.',
+  aboutManifestoText4:
+    'We ask you to donate now. Any amount you can spare will help. It will help our fighters on the frontlines to defend our Homeland. It will punish the invaders and war criminals. It will provide care to the wounded and grief-ridden. It will protect, feed, and shelter refugees. It will help Ukraine stay Ukraine.',
+  aboutDonateLink: 'Please donate',
+  aboutManifestoText5: ' to the organizations of your choice, military or humanitarian-related.  ',
+  aboutShareLink: 'Share',
+  aboutManifestoText6:
+    ' this website with your family, friends, and colleagues: anyone who wants to contribute to our cause but may not know how.',
+
+  aboutTeamHeader: 'Our Team',
+  aboutTeamMore: 'And more than 20+ volunteers from  10+ countries',
+  aboutTeamJoinHeader: 'Wanna join?',
+  aboutTeamJoinText: 'Currently we are looking for PR & SMM specialists',
+  aboutTeamJoinLink: 'Drop us a line',
+
+  aboutOrganizationHeader: 'Why these organizations?',
+  aboutOrganizationText1:
+    'We promote a list of the most popular and reliable funds with well-recorded activity or endorsed by Ukrainian officials. Our team has verified all of them.',
+  aboutOrganizationText2:
+    'You can learn more about the organization on their official website by clicking/tapping on the organization’s name.',
+  aboutOrganizationText3:
+    'Unfortunately, some don’t have English versions, but be stoic and use Google Translate if needed.',
+  aboutOrganizationText4: 'Do you know or run an organization that will help?',
+  suggestOrganization: 'Suggest an organization',
+
+  verifyHeader: 'Verify by yourself',
+  verifyUK: 'Ukrainian',
+  verifyUS: 'US-based',
+  verifyUKText1:
+    'Use YouControl first to verify a Ukrainian organization by its legal code: ЄДРПОУ (EDRPOU).',
+  verifyUKText2: '🔍 Find the EDRPOU code in our listing or on the organization website.',
+  verifyUKText3:
+    '✔︎ As a second check, confirm details in official state registries (for example, State Tax Service records).',
+
+  // widget page (discontinued — kept for key parity, falls back to EN)
+  widgetPageTitle: 'Add the widget to your site and let the audience know how to support Ukraine',
+  widgetPageHowInstall: 'How to install',
+  widgetInstallStep1: 'Pick a design version from listed below',
+  widgetInstallStep2: 'Copy widget code',
+  widgetInstallStep3: 'Add it at your website at the <head> tag',
+  widgetCopyCode: 'Copy code',
+  widgetVariant1: 'Tiny button at the bottom left',
+  widgetVariant2: 'Blue and yellow stripe stuck to top',
+  widgetVariant3: 'Black stripe with a tiny flag stuck to top',
+  widgetGTagManager: 'Alternative way: via Google Tag Manager',
+  widgetGTagStep1: 'Open your workspace. Go to Tags',
+  widgetGTagStep2: 'Create a new one',
+  widgetGTagStep3: 'Set any name you want',
+  widgetGTagStep4: 'Pick Custom HTML at the Tag configuration',
+  widgetGTagStep5: 'Paste widget code (any among above)',
+  widgetGTagStep6: 'Set All pages at Triggering. Save',
+  widgetGTagStep7: 'Refresh your site. The widget should already be there',
+  widgetWordPress: 'Alternative way: via WordPress plugin',
+  widgetWordPressSoon: 'coming soon...',
+}


### PR DESCRIPTION
Adds **European Portuguese (`pt`, 🇵🇹)** as a registered locale.

- Registers `pt` in `byLang` + `flagsMap` and adds `core/texts/pt.ts`.
- Chrome translated (informal *tu*, voice per `TRANSLATIONS_GUIDE.md`).
- About / verify / widget blocks kept in **English** — required for `TextKeys` parity (`TextKeys` is the intersection of all locales' keys), same as every other locale file.

⚠️ **AI-assisted draft — pending native PT review.** Paired with the matching `site-source` PR (donation cards + submodule bump).

Base is `translations-pass-2026-05` so this stays separate from the in-flight pass under review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
