### PR TITLE
Add Kazakh (kk) locale

### DIFF
--- a/texts/index.ts
+++ b/texts/index.ts
@@ -16,6 +16,7 @@ import ja from './ja'
 import no from './no'
 import ua from './ua'
 import ar from './ar'
+import kk from './kk'
 
 export const defaultLang = process.env.NEXT_PUBLIC_DEFAULT_LANG as Lang
 
@@ -38,6 +39,7 @@ export const byLang = {
   tr,
   // ar,
   ru,
+  kk,
 } as const
 
 export const flagsMap: Record<Lang, string> = {
@@ -59,6 +61,7 @@ export const flagsMap: Record<Lang, string> = {
   ja: '🇯🇵',
   // ar: '🇦🇪',
   ru: '🏳',
+  kk: '🇰🇿',
 }
 
 export type Lang = keyof typeof byLang

--- a/texts/kk.ts
+++ b/texts/kk.ts
@@ -1,0 +1,149 @@
+// AI-assisted draft (Kazakh / қазақша), LOW CONFIDENCE — needs thorough native review
+export default {
+  siteName: `Stand For Ukraine`,
+  siteDescription: `Украинаның әскери және гуманитарлық ұйымдарын қолда. Қарулы күштер мен соғыстан зардап шеккендерге көмектесетін тексерілген қорлар.`,
+  thumbnail: `/thumbnail.png`,
+
+  share: 'Бөлісу',
+  donate: 'Қолдау',
+  inform: 'Хабарлау',
+  donateButton: 'Қолдау',
+  spreadTheWorld: 'Spread the word',
+
+  heroTitle: 'Украинаның әскери және гуманитарлық ұйымдарын қолда',
+  heroSubtitle:
+    'Украина Қарулы күштеріне және соғыстан зардап шеккендерге көмектесу үшін тексерілген ұйымдар мен әскери қорлар.',
+  heroTagline: 'Украина үшін — Ресейдің ауқымды басып кіруіне қарсы тұр.',
+
+  close: 'Жабу',
+  sharePopupTitle: 'Үндеуді тарат',
+  sharePopupText1: 'Бұл жобаны достарың мен әріптестеріңе жібер.',
+  sharePopupText2: 'Адамдарға Украинаны қалай қолдауға болатынын көрсет.',
+  sharingText: 'Украинаның әскери және гуманитарлық ұйымдарын қолда #StandForUkraine',
+  copyLink: 'Сілтемені көшіру',
+  copyLinkDone: 'Көшірілді!',
+
+  // tags
+  All: 'Барлығы',
+  Military: 'Әскери',
+  Medical: 'Медициналық',
+  Humanitarian: 'Гуманитарлық',
+  Refugees: 'Босқындарға көмек',
+  Press: 'Баспасөз',
+  'Non-combat': 'Шайқастан тыс қолдау',
+  NGO: 'ҮЕҰ',
+  'Human Rights': 'Адам құқықтары',
+
+  // footer
+  footerMissionLead:
+    'Украинаны қолдаудың сенімді жолын табуға көмектеседі — тікелей, қауіпсіз және саған ыңғайлы түрде. Маңызды жерге қайыр бер.',
+  footerGoals: 'Біздің мақсаттарымыз',
+  goal1:
+    'Украина әскерін Ресейдің ауқымды басып кіруіне қарсы тұру үшін қару-жарақпен, оқ-дәрімен және жабдықпен қамтамасыз ету.',
+  goal2: 'Ардагерлер мен соғыс құрбандарының сауығуын қолдау.',
+  goal3: 'Қоныс аударған адамдарды баспанамен және азық-түлікпен қамтамасыз ету.',
+  goal4: 'Балаларға, қарт адамдарға және басқа да осал топтарға көмектесу.',
+  goal5: 'Тәуелсіз журналистиканы нығайту.',
+  footerCreds:
+    'Ерікті мамандар жасады — Украина мен басқа елдердің инженерлері, дизайнерлері, журналистері және белсенділері.',
+  footerContact: 'Бізге жаз',
+  joinUs: 'Бізге қосыл',
+  disclaimer:
+    'Біз қайырмалдықтарды өңдемейміз — тек сені тексерілген, ашық қорлармен байланыстырамыз.',
+  aboutProject: 'Жоба туралы',
+  suggestOrgLink: 'Ұйым ұсын',
+  sharedFeedbackLink: 'Пікір қалдыр',
+  footerVerifyYouControl: 'youcontrol.com арқылы тексеру',
+  footerLastReviewed: 'Соңғы тексеру: 2026 жылғы наурыз',
+
+  // filter
+  filterTo: 'Санат',
+  filterPayVia: 'Тәсілі',
+  resetFilter: 'Сүзгіні тазалау',
+  moreFilters: 'Қосымша сүзгілер',
+
+  // payment methods
+  IBAN: 'IBAN',
+  Crypto: 'Криптовалюта',
+  'Credit Card': 'Банк картасы',
+  PayPal: 'PayPal',
+  Patreon: 'Patreon',
+
+  copyCode: 'Кодты көшіру',
+  browseAll1: 'Барлығын көру',
+  browseAll2: 'ұйымдар',
+  browseAll3: 'жазбалар',
+
+  // legal popup
+  legalCodeLabel: 'ЄДРПОУ',
+  legalDesc1:
+    'EDRPOU (ЄДРПОУ) — Украинаның Мемлекеттік салық қызметі беретін заңды тұлғаның коды.',
+  legalDesc2: 'EDRPOU кодын көшіру',
+  legalDesc3: 'Ұйымды тізілімдегі коды бойынша тексеру',
+  legalFooterLink: 'Украинаның Мемлекеттік салық қызметі',
+
+  // about page (English-only by design — kept for key parity, falls back to EN)
+  aboutHeader: `About the Project`,
+  aboutHeaderText1: `Who we are and what we stand for.`,
+
+  aboutManifestoHeader: 'Our Manifesto',
+  aboutManifestoText1:
+    'On Feb 24, 2022, Russia, with the active support of Belarus, launched a full-scale war on Ukraine.',
+  aboutManifestoText2:
+    'We are Ukrainians. We vigorously oppose this war and demand to end it immediately. It’s an attack on our liberty and genocide of our people. We are united and strong, but we can’t take on these atrocities on our own.',
+  aboutManifestoText3:
+    'Our project is a response to the invasion. We hope to reach people across the world, of all cultures and creeds, to come together and support Ukraine in its darkest hour.',
+  aboutManifestoText4:
+    'We ask you to donate now. Any amount you can spare will help. It will help our fighters on the frontlines to defend our Homeland. It will punish the invaders and war criminals. It will provide care to the wounded and grief-ridden. It will protect, feed, and shelter refugees. It will help Ukraine stay Ukraine.',
+  aboutDonateLink: 'Please donate',
+  aboutManifestoText5: ' to the organizations of your choice, military or humanitarian-related.  ',
+  aboutShareLink: 'Share',
+  aboutManifestoText6:
+    ' this website with your family, friends, and colleagues: anyone who wants to contribute to our cause but may not know how.',
+
+  aboutTeamHeader: 'Our Team',
+  aboutTeamMore: 'And more than 20+ volunteers from  10+ countries',
+  aboutTeamJoinHeader: 'Wanna join?',
+  aboutTeamJoinText: 'Currently we are looking for PR & SMM specialists',
+  aboutTeamJoinLink: 'Drop us a line',
+
+  aboutOrganizationHeader: 'Why these organizations?',
+  aboutOrganizationText1:
+    'We promote a list of the most popular and reliable funds with well-recorded activity or endorsed by Ukrainian officials. Our team has verified all of them.',
+  aboutOrganizationText2:
+    'You can learn more about the organization on their official website by clicking/tapping on the organization’s name.',
+  aboutOrganizationText3:
+    'Unfortunately, some don’t have English versions, but be stoic and use Google Translate if needed.',
+  aboutOrganizationText4: 'Do you know or run an organization that will help?',
+  suggestOrganization: 'Suggest an organization',
+
+  verifyHeader: 'Verify by yourself',
+  verifyUK: 'Ukrainian',
+  verifyUS: 'US-based',
+  verifyUKText1:
+    'Use YouControl first to verify a Ukrainian organization by its legal code: ЄДРПОУ (EDRPOU).',
+  verifyUKText2: '🔍 Find the EDRPOU code in our listing or on the organization website.',
+  verifyUKText3:
+    '✔︎ As a second check, confirm details in official state registries (for example, State Tax Service records).',
+
+  // widget page (discontinued — kept for key parity, falls back to EN)
+  widgetPageTitle: 'Add the widget to your site and let the audience know how to support Ukraine',
+  widgetPageHowInstall: 'How to install',
+  widgetInstallStep1: 'Pick a design version from listed below',
+  widgetInstallStep2: 'Copy widget code',
+  widgetInstallStep3: 'Add it at your website at the <head> tag',
+  widgetCopyCode: 'Copy code',
+  widgetVariant1: 'Tiny button at the bottom left',
+  widgetVariant2: 'Blue and yellow stripe stuck to top',
+  widgetVariant3: 'Black stripe with a tiny flag stuck to top',
+  widgetGTagManager: 'Alternative way: via Google Tag Manager',
+  widgetGTagStep1: 'Open your workspace. Go to Tags',
+  widgetGTagStep2: 'Create a new one',
+  widgetGTagStep3: 'Set any name you want',
+  widgetGTagStep4: 'Pick Custom HTML at the Tag configuration',
+  widgetGTagStep5: 'Paste widget code (any among above)',
+  widgetGTagStep6: 'Set All pages at Triggering. Save',
+  widgetGTagStep7: 'Refresh your site. The widget should already be there',
+  widgetWordPress: 'Alternative way: via WordPress plugin',
+  widgetWordPressSoon: 'coming soon...',
+}


### PR DESCRIPTION
Adds **Kazakh (`kk`, 🇰🇿)** as a registered locale (Cyrillic, informal *сен*).

- Registers `kk` in `byLang` + `flagsMap`, adds `core/texts/kk.ts`.
- About / verify / widget blocks kept in **English** for `TextKeys` parity, same as every other locale.

> ⚠️ **LOW CONFIDENCE AI draft.** Produced without a Kazakh-reading author and with no existing `kk` file to anchor against. **Needs a thorough native review — case endings, agreement, register, terminology are all unverified.** Not a light proofread.

Paired with the matching `site-source` PR (cards + submodule bump). Independent of the Portuguese branch and of #58. Base is `translations-pass-2026-05`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
